### PR TITLE
feat: config web to export resource handler

### DIFF
--- a/src/main/java/com/example/demo/config/SecurityConfiguration.java
+++ b/src/main/java/com/example/demo/config/SecurityConfiguration.java
@@ -50,7 +50,7 @@ public class SecurityConfiguration {
                         (authz) -> authz
                                 .requestMatchers("/", "/api/v1/auth/login", "/api/v1/auth/refresh",
                                         "/api/v1/auth/register",
-                                        "/api/v1/jobs/**")
+                                        "/api/v1/jobs/**", "/uploads/company/**")
                                 .permitAll()
                                 .anyRequest().authenticated())
                 // Add BearerTokenAuthenticationFilter

--- a/src/main/java/com/example/demo/config/WebConfiguration.java
+++ b/src/main/java/com/example/demo/config/WebConfiguration.java
@@ -7,6 +7,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.Arrays;
@@ -42,5 +43,11 @@ public class WebConfiguration implements WebMvcConfigurer {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:uploads/");
     }
 }

--- a/src/main/java/com/example/demo/service/impl/StorageServiceImpl.java
+++ b/src/main/java/com/example/demo/service/impl/StorageServiceImpl.java
@@ -31,7 +31,6 @@ public class StorageServiceImpl implements StorageService {
 
     private Path root;
 
-    // TODO: move file size to application properties
     private final long MAX_FILE_SIZE = 10 * 1024 * 1024;
     private final List<String> ALLOWED_EXTENSIONS = Arrays.asList(
             "jpg", "jpeg", "png", "pdf", "doc", "docx");
@@ -83,10 +82,6 @@ public class StorageServiceImpl implements StorageService {
             return "";
         }
         return filename.substring(lastDotIndex + 1);
-    }
-
-    private void formatFileName(MultipartFile file) {
-
     }
 
     @Override
@@ -147,7 +142,6 @@ public class StorageServiceImpl implements StorageService {
             } else {
                 throw new StorageException(
                         "Could not read file: " + filename);
-
             }
         } catch (MalformedURLException e) {
             throw new StorageException("Could not read file: " + filename);


### PR DESCRIPTION
This pull request introduces improvements to file upload accessibility and resource handling in the application, along with minor code cleanups. The main changes include allowing public access to uploaded company files, configuring Spring to serve static files from the `uploads` directory, and removing unused code in the storage service implementation.

**Security and Resource Access**

* Updated `SecurityConfiguration.java` to permit public access to URLs matching `/uploads/company/**`, making uploaded company files accessible without authentication.
* Added a resource handler in `WebConfiguration.java` to serve files from the local `uploads` directory for requests matching `/uploads/**`.

**Code Cleanup**

* Removed the unused `formatFileName` method from `StorageServiceImpl.java` to simplify the codebase.
* Removed a redundant comment about moving file size configuration to application properties in `StorageServiceImpl.java`.
* Minor formatting cleanup in exception handling within the `loadAsResource` method of `StorageServiceImpl.java`.