### PR TITLE
Feat/authorization

### DIFF
--- a/src/main/java/com/example/demo/config/SecurityConfiguration.java
+++ b/src/main/java/com/example/demo/config/SecurityConfiguration.java
@@ -6,6 +6,7 @@ import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -48,10 +49,23 @@ public class SecurityConfiguration {
                 .cors(Customizer.withDefaults()) // Enable CORS
                 .authorizeHttpRequests(
                         (authz) -> authz
-                                .requestMatchers("/", "/api/v1/auth/login", "/api/v1/auth/refresh",
-                                        "/api/v1/auth/register",
-                                        "/api/v1/jobs/**", "/uploads/company/**")
+                                .requestMatchers(HttpMethod.GET,
+                                        "/api/v1/companies/**",
+                                        "/api/v1/jobs/**",
+                                        "/api/v1/minio/**",
+                                        "/api/v1/skills/**")
                                 .permitAll()
+                                .requestMatchers(
+                                        "/api/v1/resumes/**")
+                                .authenticated()
+                                .requestMatchers(HttpMethod.POST,
+                                        "/api/v1/companies/**",
+                                        "/api/v1/jobs/**",
+                                        "/api/v1/permissions/**",
+                                        "/api/v1/roles/**",
+                                        "/api/v1/users/**",
+                                        "/api/v1/minio/**")
+                                .hasRole("ADMIN")
                                 .anyRequest().authenticated())
                 // Add BearerTokenAuthenticationFilter
                 .oauth2ResourceServer((oauth2) -> oauth2.jwt(Customizer.withDefaults())
@@ -88,7 +102,7 @@ public class SecurityConfiguration {
     public JwtAuthenticationConverter jwtAuthenticationConverter() {
         JwtGrantedAuthoritiesConverter grantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
         grantedAuthoritiesConverter.setAuthorityPrefix("");
-        grantedAuthoritiesConverter.setAuthoritiesClaimName("user");
+        grantedAuthoritiesConverter.setAuthoritiesClaimName("authorities");
         JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
         jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(grantedAuthoritiesConverter);
         return jwtAuthenticationConverter;

--- a/src/main/java/com/example/demo/config/SecurityConfiguration.java
+++ b/src/main/java/com/example/demo/config/SecurityConfiguration.java
@@ -49,12 +49,6 @@ public class SecurityConfiguration {
                 .cors(Customizer.withDefaults()) // Enable CORS
                 .authorizeHttpRequests(
                         (authz) -> authz
-                                .requestMatchers(HttpMethod.GET,
-                                        "/api/v1/companies/**",
-                                        "/api/v1/jobs/**",
-                                        "/api/v1/minio/**",
-                                        "/api/v1/skills/**")
-                                .permitAll()
                                 .requestMatchers(
                                         "/api/v1/resumes/**")
                                 .authenticated()

--- a/src/main/java/com/example/demo/config/SecurityConfiguration.java
+++ b/src/main/java/com/example/demo/config/SecurityConfiguration.java
@@ -66,7 +66,7 @@ public class SecurityConfiguration {
                                         "/api/v1/users/**",
                                         "/api/v1/minio/**")
                                 .hasRole("ADMIN")
-                                .anyRequest().authenticated())
+                                .anyRequest().permitAll())
                 // Add BearerTokenAuthenticationFilter
                 .oauth2ResourceServer((oauth2) -> oauth2.jwt(Customizer.withDefaults())
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint))

--- a/src/main/java/com/example/demo/config/UserDetailCustom.java
+++ b/src/main/java/com/example/demo/config/UserDetailCustom.java
@@ -1,7 +1,10 @@
 package com.example.demo.config;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -9,6 +12,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
+import com.example.demo.entity.Permission;
+import com.example.demo.entity.Role;
 import com.example.demo.service.UserService;
 
 @Component("userDetailsService")
@@ -26,7 +31,30 @@ public class UserDetailCustom implements UserDetailsService {
         return User.builder()
                 .username(user.getEmail())
                 .password(user.getPassword())
-                .authorities(user.getRole().getName())
+                .authorities(getAuthorities(user.getRole()))
                 .build();
+    }
+
+    private List<? extends GrantedAuthority> getAuthorities(
+            Role role) {
+        return getGrantedAuthorities(getPrivileges(role));
+    }
+
+    private List<String> getPrivileges(Role role) {
+
+        List<String> privileges = new ArrayList<>();
+        privileges.add(role.getName());
+        for (Permission permission : role.getPermissions()) {
+            privileges.add(permission.getName());
+        }
+        return privileges;
+    }
+
+    private List<GrantedAuthority> getGrantedAuthorities(List<String> privileges) {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        for (String privilege : privileges) {
+            authorities.add(new SimpleGrantedAuthority(privilege));
+        }
+        return authorities;
     }
 }

--- a/src/main/java/com/example/demo/config/UserDetailCustom.java
+++ b/src/main/java/com/example/demo/config/UserDetailCustom.java
@@ -1,7 +1,6 @@
 package com.example.demo.config;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/com/example/demo/controller/AuthController.java
+++ b/src/main/java/com/example/demo/controller/AuthController.java
@@ -62,14 +62,15 @@ public class AuthController {
                                 .authenticate(authenticationToken);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
 
+                System.out.println(SecurityContextHolder.getContext());
+
                 // Format response
                 LoginResponse data = new LoginResponse();
                 String email = loginDTO.getUsername();
                 UserDTO userDTO = this.userService.convertToUserDTO(this.userService.getUserByEmail(email));
                 data.setUser(userDTO);
                 // Create JWT Access Token
-                String accessToken = this.securityService.createAccessToken(email, userDTO.getRole().getName(),
-                                userDTO);
+                String accessToken = this.securityService.createAccessToken(email, userDTO);
                 data.setAccessToken(accessToken);
 
                 // Create JWT Refresh Token and store to database
@@ -108,8 +109,7 @@ public class AuthController {
                         data.setUser(userDTO);
 
                         // Create new access token
-                        String accessToken = this.securityService.createAccessToken(email, userDTO.getRole().getName(),
-                                        userDTO);
+                        String accessToken = this.securityService.createAccessToken(email, userDTO);
                         data.setAccessToken(accessToken);
 
                         return ResponseEntity.ok().body(data);
@@ -132,8 +132,7 @@ public class AuthController {
                 UserDTO userDTO = this.userService.convertToUserDTO(user);
                 data.setUser(userDTO);
                 // Create JWT Access Token
-                String accessToken = this.securityService.createAccessToken(email, userDTO.getRole().getName(),
-                                userDTO);
+                String accessToken = this.securityService.createAccessToken(email, userDTO);
                 data.setAccessToken(accessToken);
 
                 // Create new JWT Refresh Token and Store to database

--- a/src/main/java/com/example/demo/dto/response/RegistrationResponse.java
+++ b/src/main/java/com/example/demo/dto/response/RegistrationResponse.java
@@ -20,7 +20,7 @@ public class RegistrationResponse {
     private Instant createdAt;
 
     public RegistrationResponse(Long id, String username, String email, Integer age, Gender gender, String address,
-            Instant createdAt) {
+            Instant createdAt, Role role) {
         this.id = id;
         this.username = username;
         this.email = email;

--- a/src/main/java/com/example/demo/service/SecurityService.java
+++ b/src/main/java/com/example/demo/service/SecurityService.java
@@ -2,6 +2,8 @@ package com.example.demo.service;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -20,6 +22,7 @@ import org.springframework.stereotype.Service;
 
 import com.example.demo.dto.response.UserClaims;
 import com.example.demo.dto.response.UserDTO;
+import com.example.demo.entity.Permission;
 import com.nimbusds.jose.util.Base64;
 
 @Service
@@ -45,9 +48,15 @@ public class SecurityService {
      * @param authentication Authentication information of user
      * @return JWT Token
      */
-    public String createAccessToken(String email, String role, UserDTO userDTO) {
+    public String createAccessToken(String email, UserDTO userDTO) {
         Instant now = Instant.now();
         Instant validity = now.plus(this.accessTokenExpiration, ChronoUnit.SECONDS);
+
+        List<String> authorities = new ArrayList<>();
+        for (Permission permission : userDTO.getRole().getPermissions()) {
+            authorities.add(permission.getName());
+        }
+        authorities.add(userDTO.getRole().getName());
 
         // Payload: Contain authentication information
         UserClaims userClaims = new UserClaims(userDTO);
@@ -55,7 +64,7 @@ public class SecurityService {
                 .issuedAt(now)
                 .expiresAt(validity)
                 .subject(email)
-                .claim("authorities", role)
+                .claim("authorities", authorities)
                 .claim("user", userClaims)
                 .build();
 


### PR DESCRIPTION
This pull request introduces several improvements to the authentication and authorization system, focusing on enhanced role and permission handling in JWT tokens and Spring Security configuration. The main changes include refining how user authorities are determined and stored in JWTs, updating the security filter chain to provide more granular access control, and improving the way user roles and permissions are managed throughout the authentication process.

**Authorization and Security Configuration:**

* Updated the `SecurityConfiguration` to require authentication for `/api/v1/resumes/**`, restrict `POST` requests to certain endpoints to users with the `ADMIN` role, and permit all other requests. This change introduces more granular access control based on HTTP method and endpoint.
* Changed the JWT authority claim from `"user"` to `"authorities"` in the `jwtAuthenticationConverter`, ensuring that Spring Security correctly recognizes user authorities from the JWT.

**User Authority and Permission Handling:**

* Refactored the `UserDetailCustom` class to build a list of granted authorities by combining the user's role and all associated permissions, instead of just assigning the role name. This enables finer-grained authorization checks throughout the application. [[1]](diffhunk://#diff-d71da11ae02f0f029c870d69a55d68475b85448050c5d56f27c5b6a120e70e0cL3-R15) [[2]](diffhunk://#diff-d71da11ae02f0f029c870d69a55d68475b85448050c5d56f27c5b6a120e70e0cL29-R58)
* Modified the `SecurityService.createAccessToken` method to include both the user's role and all associated permissions in the JWT's `authorities` claim, rather than just the role name. [[1]](diffhunk://#diff-7f08041f41fed438e3b7c5e0b16c4a2c9cf6d7bbb723ec5ac7af971b500da2a4R5-R6) [[2]](diffhunk://#diff-7f08041f41fed438e3b7c5e0b16c4a2c9cf6d7bbb723ec5ac7af971b500da2a4R25) [[3]](diffhunk://#diff-7f08041f41fed438e3b7c5e0b16c4a2c9cf6d7bbb723ec5ac7af971b500da2a4L48-R67)

**Authentication Flow Updates:**

* Updated all usages of `createAccessToken` in `AuthController` to remove the explicit role parameter, since authorities are now derived from the `UserDTO`, and adjusted the JWT payload accordingly. [[1]](diffhunk://#diff-e33f65ee1d56a74cf0944d2e91b7a2bf005994d27d063bd592497dca32a268caR65-R73) [[2]](diffhunk://#diff-e33f65ee1d56a74cf0944d2e91b7a2bf005994d27d063bd592497dca32a268caL111-R112) [[3]](diffhunk://#diff-e33f65ee1d56a74cf0944d2e91b7a2bf005994d27d063bd592497dca32a268caL135-R135)

These changes collectively enhance the flexibility and security of the authentication system by supporting both role-based and permission-based access control.